### PR TITLE
Terraform 0.12 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ jobs:
       if: type IN (pull_request)
       install: true
       script:
-      - docker build -t mattffffff/terraform-test:$TERRAFORM_VERSION . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
+      - docker build -t microsoft/terraform-test:$TERRAFORM_VERSION . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
     - stage: push docker image
       if: (branch = master) AND (type IN (push, api, cron))
       install: true
       script:
-      - docker build -t mattffffff/terraform-test:$TERRAFORM_VERSION -t mattffffff/terraform-test:latest . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
+      - docker build -t microsoft/terraform-test:$TERRAFORM_VERSION -t microsoft/terraform-test:latest . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
       - docker login -u="$DOCKER_USER" -p="$DOCKER_PASSWORD"
-      - docker push mattffffff/terraform-test:$TERRAFORM_VERSION
-      - docker push mattffffff/terraform-test:latest
+      - docker push microsoft/terraform-test:$TERRAFORM_VERSION
+      - docker push microsoft/terraform-test:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ jobs:
       if: type IN (pull_request)
       install: true
       script:
-      - docker build -t microsoft/terraform-test:$TERRAFORM_VERSION . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
+      - docker build -t mattffffff/terraform-test:$TERRAFORM_VERSION . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
     - stage: push docker image
       if: (branch = master) AND (type IN (push, api, cron))
       install: true
       script:
-      - docker build -t microsoft/terraform-test:$TERRAFORM_VERSION -t microsoft/terraform-test:latest . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
+      - docker build -t mattffffff/terraform-test:$TERRAFORM_VERSION -t mattffffff/terraform-test:latest . --build-arg tfver=$TERRAFORM_VERSION --build-arg gover=$GOLANG_VERSION
       - docker login -u="$DOCKER_USER" -p="$DOCKER_PASSWORD"
-      - docker push microsoft/terraform-test:$TERRAFORM_VERSION
-      - docker push microsoft/terraform-test:latest
+      - docker push mattffffff/terraform-test:$TERRAFORM_VERSION
+      - docker push mattffffff/terraform-test:latest

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Overview
 
-This Docker image (see [Dockerfile](https://github.com/matt-FFFFFF/terraform-test/blob/master/Dockerfile)) is for testing [Azure Terraform modules](https://registry.terraform.io/browse?provider=Azure).
+This Docker image (see [Dockerfile](https://github.com/Azure/terraform-test/blob/master/Dockerfile)) is for testing [Azure Terraform modules](https://registry.terraform.io/browse?provider=Azure).
 
 # Terraform 0.12
 
-This repo now supports terraform 0.12 alongside 0.11.
+This image now supports terraform 0.12 alongside 0.11.
 
 # Usage 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This Docker image (see [Dockerfile](https://github.com/Azure/terraform-test/blob/master/Dockerfile)) is for testing [Azure Terraform modules](https://registry.terraform.io/browse?provider=Azure).
+This Docker image (see [Dockerfile](https://github.com/Azure/terraform-test/blob/master/Dockerfile)) is for testing [Azure Terraform modules](https://registry.terraform.io/browse?provider=azurerm).
 
 # Terraform 0.12
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This Docker image (see [Dockerfile](https://github.com/matt-FFFFFF/terraform-tes
 
 # Terraform 0.12
 
-This repo has been forked and updated to support Terraform 0.12. It creates the Docker hub image mattffffff/terraform-test.
+This repo now supports terraform 0.12 alongside 0.11.
+
 # Usage 
 
 This image can be used for terraform lint or end to end tests against Azure.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This Docker image (see [Dockerfile](https://github.com/Azure/terraform-test/blob/master/Dockerfile)) is for testing [Azure Terraform modules](https://registry.terraform.io/browse?provider=azurerm).
 
+[![Build Status](https://travis-ci.org/Azure/terraform-test.svg?branch=master)](https://travis-ci.org/Azure/terraform-test)
+
 # Terraform 0.12
 
 This image now supports terraform 0.12 alongside 0.11.

--- a/build/static_utils.rb
+++ b/build/static_utils.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 def lint_tf
   # Do the linting on current working folder.
   print "INFO: Linting Terraform configurations...\n".yellow  
-  message = `terraform validate -check-variables=false 2>&1`
+  message = `terraform validate 2>&1`
 
   # Check the linting message.
   if not message.empty?
@@ -17,7 +17,7 @@ end
 def style_tf
   # Do the style checking on current working folder.
   print "INFO: Styling Terraform configurations...\n".yellow  
-  message = `terraform fmt -check=true 2>&1`
+  message = `terraform fmt -check 2>&1`
 
   # Check the styling message.
   if not message.empty?
@@ -30,7 +30,7 @@ end
 def format_tf
   # Apply the canonical format and style on current working folder.
   print "INFO: Formatting Terraform configurations...\n".yellow  
-  message = `terraform fmt -diff=true 2>&1`
+  message = `terraform fmt -diff 2>&1`
 
   # Check the styling message.
   if not message.empty?

--- a/build/static_utils.rb
+++ b/build/static_utils.rb
@@ -6,7 +6,7 @@ def lint_tf
   print "INFO: Linting Terraform configurations...\n".yellow  
   
   if ENV['TERRAFORM_VERSION'].start_with?("0.12")
-    message = `terraform validate -check-variables=false >/dev/null`
+    message = `terraform validate >/dev/null`
   elsif ENV['TERRAFORM_VERSION'].start_with?("0.11")
     message = `terraform validate -check-variables=false 2>&1`
   end

--- a/build/static_utils.rb
+++ b/build/static_utils.rb
@@ -4,7 +4,12 @@ require 'fileutils'
 def lint_tf
   # Do the linting on current working folder.
   print "INFO: Linting Terraform configurations...\n".yellow  
-  message = `terraform validate >/dev/null`
+  
+  if ENV['TERRAFORM_VERSION'].start_with?("0.12")
+    message = `terraform validate >/dev/null`
+  elsif ENV['TERRAFORM_VERSION'].start_with?("0.11")
+    message = `terraform validate -check-variables=true 2>&1`
+  end
 
   # Check the linting message.
   if not message.empty?
@@ -17,7 +22,11 @@ end
 def style_tf
   # Do the style checking on current working folder.
   print "INFO: Styling Terraform configurations...\n".yellow  
-  message = `terraform fmt -check 2>&1`
+  if ENV['TERRAFORM_VERSION'].start_with?("0.12")
+    message = `terraform fmt -check 2>&1`
+  elsif ENV['TERRAFORM_VERSION'].start_with?("0.11")
+    message = `terraform fmt -check=true 2>&1`
+  end
 
   # Check the styling message.
   if not message.empty?
@@ -29,8 +38,12 @@ end
 
 def format_tf
   # Apply the canonical format and style on current working folder.
-  print "INFO: Formatting Terraform configurations...\n".yellow  
-  message = `terraform fmt -diff 2>&1`
+  print "INFO: Formatting Terraform configurations...\n".yellow
+  if ENV['TERRAFORM_VERSION'].start_with?("0.12")
+    message = `terraform fmt -diff 2>&1`
+  elsif ENV['TERRAFORM_VERSION'].start_with?("0.11")
+    message = `terraform fmt -diff=true 2>&1`
+  end
 
   # Check the styling message.
   if not message.empty?

--- a/build/static_utils.rb
+++ b/build/static_utils.rb
@@ -4,7 +4,7 @@ require 'fileutils'
 def lint_tf
   # Do the linting on current working folder.
   print "INFO: Linting Terraform configurations...\n".yellow  
-  message = `terraform validate 2>&1`
+  message = `terraform validate >/dev/null`
 
   # Check the linting message.
   if not message.empty?

--- a/build/static_utils.rb
+++ b/build/static_utils.rb
@@ -6,9 +6,9 @@ def lint_tf
   print "INFO: Linting Terraform configurations...\n".yellow  
   
   if ENV['TERRAFORM_VERSION'].start_with?("0.12")
-    message = `terraform validate >/dev/null`
+    message = `terraform validate -check-variables=false >/dev/null`
   elsif ENV['TERRAFORM_VERSION'].start_with?("0.11")
-    message = `terraform validate -check-variables=true 2>&1`
+    message = `terraform validate -check-variables=false 2>&1`
   end
 
   # Check the linting message.


### PR DESCRIPTION
I have updated static_utils.rb to support terraform 0.12 command syntax. Uses ENV variable TERRAFORM_VERSION to determine the command to run.

If accepted, I will also update [terramodtest](https://github.com/Azure/terramodtest) with the same changes.